### PR TITLE
Compile native sources for arm64

### DIFF
--- a/libuvccamera/src/main/jni/Application.mk
+++ b/libuvccamera/src/main/jni/Application.mk
@@ -23,6 +23,6 @@
 #*/
 
 APP_PLATFORM := android-14
-APP_ABI := armeabi armeabi-v7a x86 mips
+APP_ABI := armeabi armeabi-v7a x86 mips arm64-v8a
 #APP_OPTIM := debug
 APP_OPTIM := release


### PR DESCRIPTION
This makes it work on arm64 devices. Fixes https://github.com/saki4510t/UVCCamera/issues/105 for me...