### PR TITLE
Update UVCCamera.java

### DIFF
--- a/libuvccamera/src/main/java/com/serenegiant/usb/UVCCamera.java
+++ b/libuvccamera/src/main/java/com/serenegiant/usb/UVCCamera.java
@@ -347,12 +347,15 @@ public class UVCCamera {
 			final int format_nums = formats.length();
 			for (int i = 0; i < format_nums; i++) {
 				final JSONObject format = formats.getJSONObject(i);
-				final int format_type = format.getInt("type");
-				if ((format_type == type) || (type == -1)) {
-					addSize(format, format_type, 0, result);
+				if(format.has("type") && format.has("size")) {
+					final int format_type = format.getInt("type");
+					if ((format_type == type) || (type == -1)) {
+						addSize(format, format_type, 0, result);
+					}
 				}
 			}
 		} catch (final JSONException e) {
+			e.printStackTrace();
 		}
 		return result;
 	}


### PR DESCRIPTION
For some Cameras (i.e. Logitech C920) there is an empty element in the formats array and then the result for all supported sizes was just the empty array.

Json Example:
`{"formats":[ {"index":1,"type":4,"default":1,"size":["640x480","..."] }, { }, {"index":3,"type":6,"default":1,"size":["640x480","..."]} ] }`