### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ setPreviewTexture method in UVCCamera.java etc.), but we have not confirm whethe
 project run on Android 3.1 yet.
 Some sample projects need API>=18 though.
 
-###2014/07/25
+### 2014/07/25
 Add some modification to the library and new sample project named "USBCameraTest2".
 This new sample project demonstrate how to capture movie using frame data from
 UVC camera with MediaCodec and MediaMuxer.
@@ -82,7 +82,7 @@ New sample requires at least Android 4.3(API>=18).
 This limitation does not come from the library itself but from the limitation of
 MediaMuxer and MediaCodec#createInputSurface.
 
-###2014/09/01
+### 2014/09/01
 Add new sample project named `USBCameraTest3`
 This new sample project demonstrate how to capture audio and movie simultaneously
 using frame data from UVC camera and internal mic with MediaCodec and MediaMuxer.
@@ -91,73 +91,73 @@ save as jpeg) This sample also requires at least Android 4.3(API>=18).
 This limitation does not come from the library itself but from the limitation of
 MediaMuxer and MediaCodec#createInputSurface.
 
-###2014/11/16
+### 2014/11/16
 Add new sample project named `USBCameraTest4`
 This new sample project mainly demonstrate how to use offscreen rendering
 and record movie without any display.
 The communication with camera execute as Service and continue working
 even if you stop app. If you stop camera communication, click "stop service" button.
 
-###2014/12/17
+### 2014/12/17
 Add bulk transfer mode and update sample projects.
 
-###2015/01/12
+### 2015/01/12
 Add wiki page, [HowTo](https://github.com/saki4510t/UVCCamera/wiki/howto "HowTo")
 
-###2015/01/22
+### 2015/01/22
 Add method to adjust preview resolution and frame data mode.
 
-###2015/02/12
+### 2015/02/12
 Add IFrameCallback interface to get frame data as ByteArray
 and new sample project `USBCameraTest5` to demonstrate how to use the callback method.
 
-###2015/02/18
+### 2015/02/18
 Add `libUVCCamera` as a library project(source code is almost same as previous release except Android.mk).
 All files and directories under `library` directory is deprecated.
 
-###2015/05/25
+### 2015/05/25
 libraryProject branch merged to master.
 
-###2015/05/30
+### 2015/05/30
 Fixed the issue that DeviceFilter class could not work well when providing venderID, productID etc.
 
-###2015/06/03
+### 2015/06/03
 Add new sample project named `USBCameraTest6`
 This new sample project mainly demonstrate how to show video images on two TextureView simultaneously, side by side.
 
-###2015/06/10
+### 2015/06/10
 Fixed the issue of pixel format is wrong when NV21 mode on calling IFrameCallback#onFrame(U and V plane was swapped) and added YUV420SP mode.
 
-###2015/06/11
+### 2015/06/11
 Improve the issue of `USBCameraTest4` that fails to connect/disconnect.
 
-###2015/07/19
+### 2015/07/19
 Add new methods to get/set camera features like brightness, contrast etc.  
 Add new method to get supported resolution from camera as json format.  
 
-###2015/08/17
+### 2015/08/17
 Add new sample project `USBCameraTest7` to demonstrate how to use two camera at the same time.  
 
-###2015/09/20
+### 2015/09/20
 Fixed the issue that building native libraries fail on Windows.
 
-###2015/10/30
+### 2015/10/30
 Merge pull request(add status and button callback). Thanks Alexey Pelykh.
 
-###2015/12/16
+### 2015/12/16
 Add feature so that user can request fps range from Java code when negotiating with camera. Actual resulted fps depends on each UVC camera. Currently there is no way to get resulted fps(will add on future).
 
-###2016/03/01
+### 2016/03/01
 update minoru001 branch, experimentaly support streo camera.
 
-###2016/06/18
+### 2016/06/18
 replace libjpeg-turbo 1.4.0 with 1.5.0
 
-###2016/11/17
+### 2016/11/17
 apply bandwidth factor setting of usbcameratest7 on master branch
 
-###2016/11/21
+### 2016/11/21
 Now this repository supports Android N(7.x) and dynamic permission model of Android N and later.
 
-###2017/01/16
+### 2017/01/16
 Add new sample app `usbCameraTest8` to show how to set/get uvc control like brightness 

--- a/libuvccamera/src/main/jni/rapidjson/doc/encoding.md
+++ b/libuvccamera/src/main/jni/rapidjson/doc/encoding.md
@@ -122,7 +122,7 @@ Although the encoding functions in RapidJSON are designed for JSON parsing/gener
 Here is an example for transcoding a string from UTF-8 to UTF-16:
 
 ~~~~~~~~~~cpp
-#include "rapidjson/encodings.h"
+# include "rapidjson/encodings.h"
 
 using namespace rapidjson;
 

--- a/libuvccamera/src/main/jni/rapidjson/doc/sax.md
+++ b/libuvccamera/src/main/jni/rapidjson/doc/sax.md
@@ -53,8 +53,8 @@ EndObject(7)
 These events can be easily matched with the JSON, except some event parameters need further explanation. Let's see the `simplereader` example which produces exactly the same output as above:
 
 ~~~~~~~~~~cpp
-#include "rapidjson/reader.h"
-#include <iostream>
+# include "rapidjson/reader.h"
+# include <iostream>
 
 using namespace rapidjson;
 using namespace std;
@@ -182,9 +182,9 @@ If an error occurs during parsing, it will return `false`. User can also calls `
 In `simplewriter` example, we do exactly the reverse of `simplereader`.
 
 ~~~~~~~~~~cpp
-#include "rapidjson/writer.h"
-#include "rapidjson/stringbuffer.h"
-#include <iostream>
+# include "rapidjson/writer.h"
+# include "rapidjson/stringbuffer.h"
+# include <iostream>
 
 using namespace rapidjson;
 using namespace std;
@@ -288,11 +288,11 @@ User may uses `Reader` to build other data structures directly. This eliminates 
 In the following `messagereader` example, `ParseMessages()` parses a JSON which should be an object with key-string pairs.
 
 ~~~~~~~~~~cpp
-#include "rapidjson/reader.h"
-#include "rapidjson/error/en.h"
-#include <iostream>
-#include <string>
-#include <map>
+# include "rapidjson/reader.h"
+# include "rapidjson/error/en.h"
+# include <iostream>
+# include <string>
+# include <map>
 
 using namespace std;
 using namespace rapidjson;
@@ -396,13 +396,13 @@ As mentioned earlier, `Writer` can handle the events published by `Reader`. `con
 Actually, we can add intermediate layer(s) to filter the contents of JSON via these SAX-style API. For example, `capitalize` example capitalize all strings in a JSON.
 
 ~~~~~~~~~~cpp
-#include "rapidjson/reader.h"
-#include "rapidjson/writer.h"
-#include "rapidjson/filereadstream.h"
-#include "rapidjson/filewritestream.h"
-#include "rapidjson/error/en.h"
-#include <vector>
-#include <cctype>
+# include "rapidjson/reader.h"
+# include "rapidjson/writer.h"
+# include "rapidjson/filereadstream.h"
+# include "rapidjson/filewritestream.h"
+# include "rapidjson/error/en.h"
+# include <vector>
+# include <cctype>
 
 using namespace rapidjson;
 

--- a/libuvccamera/src/main/jni/rapidjson/doc/stream.md
+++ b/libuvccamera/src/main/jni/rapidjson/doc/stream.md
@@ -13,7 +13,7 @@ Memory streams store JSON in memory.
 `StringStream` is the most basic input stream. It represents a complete, read-only JSON stored in memory. It is defined in `rapidjson/rapidjson.h`.
 
 ~~~~~~~~~~cpp
-#include "rapidjson/document.h" // will include "rapidjson/rapidjson.h"
+# include "rapidjson/document.h" // will include "rapidjson/rapidjson.h"
 
 using namespace rapidjson;
 
@@ -41,7 +41,7 @@ Note that, `StringStream` is a typedef of `GenericStringStream<UTF8<> >`, user m
 `StringBuffer` is a simple output stream. It allocates a memory buffer for writing the whole JSON. Use `GetString()` to obtain the buffer.
 
 ~~~~~~~~~~cpp
-#include "rapidjson/stringbuffer.h"
+# include "rapidjson/stringbuffer.h"
 
 StringBuffer buffer;
 Writer<StringBuffer> writer(buffer);
@@ -72,8 +72,8 @@ However, if the JSON is big, or memory is limited, you can use `FileReadStream`.
 `FileReadStream` reads the file via a `FILE` pointer. And user need to provide a buffer.
 
 ~~~~~~~~~~cpp
-#include "rapidjson/filereadstream.h"
-#include <cstdio>
+# include "rapidjson/filereadstream.h"
+# include <cstdio>
 
 using namespace rapidjson;
 
@@ -97,8 +97,8 @@ Apart from reading file, user can also use `FileReadStream` to read `stdin`.
 `FileWriteStream` is buffered output stream. Its usage is very similar to `FileReadStream`.
 
 ~~~~~~~~~~cpp
-#include "rapidjson/filewritestream.h"
-#include <cstdio>
+# include "rapidjson/filewritestream.h"
+# include <cstdio>
 
 using namespace rapidjson;
 
@@ -136,10 +136,10 @@ Note that, these encoded streams can be applied to streams other than file. For 
 `EncodedInputStream` has two template parameters. The first one is a `Encoding` class, such as `UTF8`, `UTF16LE`, defined in `rapidjson/encodings.h`. The second one is the class of stream to be wrapped.
 
 ~~~~~~~~~~cpp
-#include "rapidjson/document.h"
-#include "rapidjson/filereadstream.h"   // FileReadStream
-#include "rapidjson/encodedstream.h"    // EncodedInputStream
-#include <cstdio>
+# include "rapidjson/document.h"
+# include "rapidjson/filereadstream.h"   // FileReadStream
+# include "rapidjson/encodedstream.h"    // EncodedInputStream
+# include <cstdio>
 
 using namespace rapidjson;
 
@@ -161,9 +161,9 @@ fclose(fp);
 `EncodedOutputStream` is similar but it has a `bool putBOM` parameter in the constructor, controlling whether to write BOM into output byte stream.
 
 ~~~~~~~~~~cpp
-#include "rapidjson/filewritestream.h"  // FileWriteStream
-#include "rapidjson/encodedstream.h"    // EncodedOutputStream
-#include <cstdio>
+# include "rapidjson/filewritestream.h"  // FileWriteStream
+# include "rapidjson/encodedstream.h"    // EncodedOutputStream
+# include <cstdio>
 
 Document d;         // Document is GenericDocument<UTF8<> > 
 // ...
@@ -189,10 +189,10 @@ Sometimes an application may want to handle all supported JSON encoding. `AutoUT
 Since the characters (code units) may be 8-bit, 16-bit or 32-bit. `AutoUTFInputStream` requires a character type which can hold at least 32-bit. We may use `unsigned`, as in the template parameter:
 
 ~~~~~~~~~~cpp
-#include "rapidjson/document.h"
-#include "rapidjson/filereadstream.h"   // FileReadStream
-#include "rapidjson/encodedstream.h"    // AutoUTFInputStream
-#include <cstdio>
+# include "rapidjson/document.h"
+# include "rapidjson/filereadstream.h"   // FileReadStream
+# include "rapidjson/encodedstream.h"    // AutoUTFInputStream
+# include <cstdio>
 
 using namespace rapidjson;
 

--- a/libuvccamera/src/main/jni/rapidjson/doc/tutorial.md
+++ b/libuvccamera/src/main/jni/rapidjson/doc/tutorial.md
@@ -29,7 +29,7 @@ Assumes we have a JSON stored in a C string (`const char* json`):
 
 Parse it into a `Document`
 ~~~~~~~~~~cpp
-#include "rapidjson/document.h"
+# include "rapidjson/document.h"
 
 using namespace rapidjson;
 

--- a/libuvccamera/src/main/jni/rapidjson/readme.md
+++ b/libuvccamera/src/main/jni/rapidjson/readme.md
@@ -63,10 +63,10 @@ This simple example parses a JSON string into a document (DOM), make a simple mo
 
 ~~~~~~~~~~cpp
 // rapidjson/example/simpledom/simpledom.cpp`
-#include "rapidjson/document.h"
-#include "rapidjson/writer.h"
-#include "rapidjson/stringbuffer.h"
-#include <iostream>
+# include "rapidjson/document.h"
+# include "rapidjson/writer.h"
+# include "rapidjson/stringbuffer.h"
+# include <iostream>
 
 using namespace rapidjson;
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
