### PR TITLE
Support for cameras that do not have 640x480 in USBTest0

### DIFF
--- a/libuvccamera/src/main/java/com/serenegiant/usb/UVCCamera.java
+++ b/libuvccamera/src/main/java/com/serenegiant/usb/UVCCamera.java
@@ -333,8 +333,20 @@ public class UVCCamera {
 		}
 	}
 
+	/**
+	 * Get list of sizes for the current frame format
+	 */
 	public List<Size> getSupportedSizeList() {
 		final int type = (mCurrentFrameFormat > 0) ? 6 : 4;
+		return getSupportedSize(type, mSupportedSize);
+	}
+
+	/**
+	 * Get list of sizes for a specific frame format
+	 * @param frameFormat either FRAME_FORMAT_YUYV(0) or FRAME_FORMAT_MJPEG(1)
+	 */
+	public List<Size> getSupportedSizeList(int frameFormat) {
+		final int type = (frameFormat > 0) ? 6 : 4;
 		return getSupportedSize(type, mSupportedSize);
 	}
 

--- a/usbCameraTest0/src/main/java/com/serenegiant/usbcameratest0/MainActivity.java
+++ b/usbCameraTest0/src/main/java/com/serenegiant/usbcameratest0/MainActivity.java
@@ -36,10 +36,15 @@ import android.widget.Toast;
 
 import com.serenegiant.common.BaseActivity;
 import com.serenegiant.usb.CameraDialog;
+import com.serenegiant.usb.IFrameCallback;
+import com.serenegiant.usb.Size;
 import com.serenegiant.usb.USBMonitor;
 import com.serenegiant.usb.USBMonitor.OnDeviceConnectListener;
 import com.serenegiant.usb.USBMonitor.UsbControlBlock;
 import com.serenegiant.usb.UVCCamera;
+
+import java.nio.ByteBuffer;
+import java.util.List;
 
 public class MainActivity extends BaseActivity implements CameraDialog.CameraDialogParent {
 	private static final boolean DEBUG = true;	// TODO set false when production
@@ -148,12 +153,60 @@ public class MainActivity extends BaseActivity implements CameraDialog.CameraDia
 						final UVCCamera camera = new UVCCamera();
 						camera.open(ctrlBlock);
 						if (DEBUG) Log.i(TAG, "supportedSize:" + camera.getSupportedSize());
+
+						List<Size> mjpeg_camera_sizes = camera.getSupportedSizeList(UVCCamera.FRAME_FORMAT_MJPEG);
+						List<Size> yuv_camera_sizes = camera.getSupportedSizeList(UVCCamera.FRAME_FORMAT_YUYV);
+
+						// Pick the size that is closest to our required resolution
+						int required_width = 640;
+						int required_height = 480;
+						int required_area = required_width * required_height;
+
+						int preview_width = 0;
+						int preview_height = 0;
+						int error = Integer.MAX_VALUE; // trying to get this as small as possible
+
+						for (Size s : mjpeg_camera_sizes) {
+							// calculate the area for each camera size
+							int s_area = s.width * s.height;
+							// calculate the difference between this size and the target size
+							int abs_error = Math.abs(s_area - required_area);
+							// check if the abs_error is smaller than what we have already
+							// then use the new size
+							if (abs_error < error){
+								preview_width = s.width;
+								preview_height = s.height;
+								error = abs_error;
+							}
+						}
+
 						try {
-							camera.setPreviewSize(UVCCamera.DEFAULT_PREVIEW_WIDTH, UVCCamera.DEFAULT_PREVIEW_HEIGHT, UVCCamera.FRAME_FORMAT_MJPEG);
+							camera.setPreviewSize(preview_width, preview_height, UVCCamera.FRAME_FORMAT_MJPEG);
 						} catch (final IllegalArgumentException e) {
 							try {
 								// fallback to YUV mode
-								camera.setPreviewSize(UVCCamera.DEFAULT_PREVIEW_WIDTH, UVCCamera.DEFAULT_PREVIEW_HEIGHT, UVCCamera.DEFAULT_PREVIEW_MODE);
+
+								// find closest matching size
+								// Pick the size that is closest to our required resolution
+								int yuv_preview_width = 0;
+								int yuv_preview_height = 0;
+								int yuv_error = Integer.MAX_VALUE; // trying to get this as small as possible
+
+								for (Size s : yuv_camera_sizes) {
+									// calculate the area for each camera size
+									int s_area = s.width * s.height;
+									// calculate the difference between this size and the target size
+									int abs_error = Math.abs(s_area - required_area);
+									// check if the abs_error is smaller than what we have already
+									// then use the new size
+									if (abs_error < yuv_error) {
+										yuv_preview_width = s.width;
+										yuv_preview_height = s.height;
+										yuv_error = abs_error;
+									}
+								}
+
+								camera.setPreviewSize(yuv_preview_width, yuv_preview_height, UVCCamera.FRAME_FORMAT_YUYV);
 							} catch (final IllegalArgumentException e1) {
 								camera.destroy();
 								return;


### PR DESCRIPTION
This PR is for review.

USBTest0 (and all the other Tests) are hard coded to open the UVC Camera with the resolution 640x480.

I have a UVC camera that does not have this resolution and so all the samples fail and require code changes before they will run. The closest match for my camera is a 640x400 resolution.

I have changed USBTest0 to request a list of valid sizes from the camera. I then find the nearest match to 640x480 and use the nearest match (in my case 640x400)

The change allows USB Test 0 to work on all my UVC cameras.


I have put the 'nearest match' code in USB Test 0 and it is duplicated, one for MJPEG and one for YUV. I can move this into the UVCCamera class if required so it is in a central location.
Also I'm not sure how to fix the other examples that set the Surface aspect ratio before the camera is opened. Those samples need to have the creation of the surface delayed until after UVCCamera.Open() so for now I've just fixed Test0

Please let me know if you want to move the 'nearest match' function to the UVCcamera class and I can modify the PR.


The change also fixes a small bug.
Opening in YUV Mode used the parameter UVCCamera.DEFAULT_PREVIEW_MODE
This should be UVCCamera.FRAME_FORMAT_YUYV.
Both have a value of 0 so the sample worked but this uses the correct parameter.