### PR TITLE
Fix use after free.

### DIFF
--- a/libuvccamera/src/main/jni/libusb/libusb/io.c
+++ b/libuvccamera/src/main/jni/libusb/libusb/io.c
@@ -1362,7 +1362,6 @@ void API_EXPORTED libusb_free_transfer(struct libusb_transfer *transfer) {
 	itransfer = LIBUSB_TRANSFER_TO_USBI_TRANSFER(transfer);
 	usbi_mutex_destroy(&itransfer->lock);
 	free(itransfer);
-	transfer->user_data = NULL;	// XXX
 }
 
 #ifdef USBI_TIMERFD_AVAILABLE


### PR DESCRIPTION
In the function libusb_free_transfer, the transfer object is freed and then on the next line transfer->user_data is set to NULL.
This caused random heap corruption, and the assignment seems redundant as the object is no longer in use.