### PR TITLE
Update stream.c

### DIFF
--- a/libuvccamera/src/main/jni/libuvc/src/stream.c
+++ b/libuvccamera/src/main/jni/libuvc/src/stream.c
@@ -381,11 +381,11 @@ static uvc_error_t _prepare_stream_ctrl(uvc_device_handle_t *devh, uvc_stream_ct
 	// XXX some camera may need to call uvc_query_stream_ctrl with UVC_GET_CUR/UVC_GET_MAX/UVC_GET_MIN
 	// before negotiation otherwise stream stall. added by saki
 	uvc_error_t result = uvc_query_stream_ctrl(devh, ctrl, 1, UVC_GET_CUR);	// probe query
-	if (LIKELY(!result)) {
+	if (LIKELY(result)) {
 		result = uvc_query_stream_ctrl(devh, ctrl, 1, UVC_GET_MIN);			// probe query
-		if (LIKELY(!result)) {
+		if (LIKELY(result)) {
 			result = uvc_query_stream_ctrl(devh, ctrl, 1, UVC_GET_MAX);		// probe query
-			if (UNLIKELY(result))
+			if (UNLIKELY(!result))
 				LOGE("uvc_query_stream_ctrl:UVC_GET_MAX:err=%d", result);	// XXX 最大値の方を後で取得しないとだめ
 		} else {
 			LOGE("uvc_query_stream_ctrl:UVC_GET_MIN:err=%d", result);


### PR DESCRIPTION
if device support `UVC_GET_CUR` only, after it success(`result == 0`) `_prepare_stream_ctrl` should not try `UVC_GET_MIN` etc.