### PR TITLE
Auto-set default preview size and format for different cameras

### DIFF
--- a/usbCameraTest/src/main/java/com/serenegiant/usbcameratest/MainActivity.java
+++ b/usbCameraTest/src/main/java/com/serenegiant/usbcameratest/MainActivity.java
@@ -139,7 +139,12 @@ public final class MainActivity extends BaseActivity implements CameraDialog.Cam
 				@Override
 				public void run() {
 					final UVCCamera camera = new UVCCamera();
-					camera.open(ctrlBlock);
+					try {
+						camera.open(ctrlBlock);
+					} catch (final UnsupportedOperationException | IllegalArgumentException e) {
+						camera.destroy();
+						return;
+					}
 					camera.setStatusCallback(new IStatusCallback() {
 						@Override
 						public void onStatus(final int statusClass, final int event, final int selector,
@@ -187,17 +192,6 @@ public final class MainActivity extends BaseActivity implements CameraDialog.Cam
 					if (mPreviewSurface != null) {
 						mPreviewSurface.release();
 						mPreviewSurface = null;
-					}
-					try {
-						camera.setPreviewSize(UVCCamera.DEFAULT_PREVIEW_WIDTH, UVCCamera.DEFAULT_PREVIEW_HEIGHT, UVCCamera.FRAME_FORMAT_MJPEG);
-					} catch (final IllegalArgumentException e) {
-						// fallback to YUV mode
-						try {
-							camera.setPreviewSize(UVCCamera.DEFAULT_PREVIEW_WIDTH, UVCCamera.DEFAULT_PREVIEW_HEIGHT, UVCCamera.DEFAULT_PREVIEW_MODE);
-						} catch (final IllegalArgumentException e1) {
-							camera.destroy();
-							return;
-						}
 					}
 					final SurfaceTexture st = mUVCCameraView.getSurfaceTexture();
 					if (st != null) {

--- a/usbCameraTest0/src/main/java/com/serenegiant/usbcameratest0/MainActivity.java
+++ b/usbCameraTest0/src/main/java/com/serenegiant/usbcameratest0/MainActivity.java
@@ -146,18 +146,12 @@ public class MainActivity extends BaseActivity implements CameraDialog.CameraDia
 				public void run() {
 					synchronized (mSync) {
 						final UVCCamera camera = new UVCCamera();
-						camera.open(ctrlBlock);
-						if (DEBUG) Log.i(TAG, "supportedSize:" + camera.getSupportedSize());
 						try {
-							camera.setPreviewSize(UVCCamera.DEFAULT_PREVIEW_WIDTH, UVCCamera.DEFAULT_PREVIEW_HEIGHT, UVCCamera.FRAME_FORMAT_MJPEG);
-						} catch (final IllegalArgumentException e) {
-							try {
-								// fallback to YUV mode
-								camera.setPreviewSize(UVCCamera.DEFAULT_PREVIEW_WIDTH, UVCCamera.DEFAULT_PREVIEW_HEIGHT, UVCCamera.DEFAULT_PREVIEW_MODE);
-							} catch (final IllegalArgumentException e1) {
-								camera.destroy();
-								return;
-							}
+							camera.open(ctrlBlock);
+							if (DEBUG) Log.i(TAG, "supportedSize:" + camera.getSupportedSize());
+						} catch (final UnsupportedOperationException | IllegalArgumentException e) {
+							camera.destroy();
+							return;
 						}
 						mPreviewSurface = mUVCCameraView.getHolder().getSurface();
 						if (mPreviewSurface != null) {

--- a/usbCameraTest2/src/main/java/com/serenegiant/usbcameratest2/MainActivity.java
+++ b/usbCameraTest2/src/main/java/com/serenegiant/usbcameratest2/MainActivity.java
@@ -188,22 +188,15 @@ public final class MainActivity extends BaseActivity implements CameraDialog.Cam
 				@Override
 				public void run() {
 					final UVCCamera camera = new UVCCamera();
-					camera.open(ctrlBlock);
-					if (DEBUG) Log.i(TAG, "supportedSize:" + camera.getSupportedSize());
+					try {
+						camera.open(ctrlBlock);
+                        if (DEBUG) Log.i(TAG, "supportedSize:" + camera.getSupportedSize());
+					} catch (final UnsupportedOperationException | IllegalArgumentException e) {
+						camera.destroy();
+					}
 					if (mPreviewSurface != null) {
 						mPreviewSurface.release();
 						mPreviewSurface = null;
-					}
-					try {
-						camera.setPreviewSize(UVCCamera.DEFAULT_PREVIEW_WIDTH, UVCCamera.DEFAULT_PREVIEW_HEIGHT, UVCCamera.FRAME_FORMAT_MJPEG);
-					} catch (final IllegalArgumentException e) {
-						try {
-							// fallback to YUV mode
-							camera.setPreviewSize(UVCCamera.DEFAULT_PREVIEW_WIDTH, UVCCamera.DEFAULT_PREVIEW_HEIGHT, UVCCamera.DEFAULT_PREVIEW_MODE);
-						} catch (final IllegalArgumentException e1) {
-							camera.destroy();
-							return;
-						}
 					}
 					final SurfaceTexture st = mUVCCameraView.getSurfaceTexture();
 					if (st != null) {


### PR DESCRIPTION
Current samples need to set preview size and format in samples or wrappers. That is, an UVC app using this library won't work on all cameras with different size or format.

In #175, Roger has applied usbCameraTest0 to adapt different size with least area error.

Different from his contribution, my work tries to find proper size and format with least absolute error of width and height, which is directly implemented in library instead of app.
The two commits work fine on my two cameras, one is 640x480@MJPEG and the other is 50x50@YUYV.

The PR needs to be reviewed, thanks.