### PR TITLE
Safely build 64-bit binaries along with some modernization.

### DIFF
--- a/libuvccamera/src/main/jni/Application.mk
+++ b/libuvccamera/src/main/jni/Application.mk
@@ -27,6 +27,6 @@
 #NDK_TOOLCHAIN_VERSION := 4.9
 
 APP_PLATFORM := android-14
-APP_ABI := armeabi armeabi-v7a x86 mips
+APP_ABI := all
 #APP_OPTIM := debug
 APP_OPTIM := release


### PR DESCRIPTION
This pull-req contains several changes to come over 32-bit/64-bit situation of [new Google Play's policy](https://android-developers.googleblog.com/2017/12/improving-app-security-and-performance.html).

Changes made:

 - Remove mips from `APP_ABI` because recent NDK lacks support for them
   - Specifying `all` is reasonable especially for recent NDKs because at least NDK r18 complains `armeabi` is deprecated.
 - Upgrade Gradle and corresponding build scripts for better app integration
   - Also upgrade `versionBuildTool` to align build tools with Android gradle plugin
 - Specify `https` instead of `http` for URI schema of libcommon to avoid possible DNS poisoning attack

Note: According to recent Google's annoucements, APK size issue addressed [here](https://github.com/saki4510t/UVCCamera/wiki/How-to-exclude-native-binaries-for-specific-architecture(s)) is meant to be mitigated via [Android App Bundle](https://codelabs.developers.google.com/codelabs/your-first-dynamic-app/index.html?index=..%2F..%2Fio2018#0).

Note: You will see `Android NDK: android-14 is unsupported. Using minimum supported version android-16.` warning when built with NDK r18 but you can easilly fix this by specifying older NDKs on `local.properties` file if you really need to keep support for Android 4.0.x. I assume most developers (targetting android-16+) can harmlessly ignore this warning because their app themselves will be compiled with `minSdkVersion 16` or later.