### PR TITLE
(mod) prepare UVCCamera for Android Oreo

### DIFF
--- a/usbCameraTest/src/main/AndroidManifest.xml
+++ b/usbCameraTest/src/main/AndroidManifest.xml
@@ -28,7 +28,7 @@
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
-        android:theme="@style/AppTheme" >
+        android:theme="@style/Theme.AppCompat" >
         <activity
             android:name="com.serenegiant.usbcameratest.MainActivity"
             android:label="@string/app_name" >
@@ -36,6 +36,17 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+<!--uncomment to get permanent USB Permission
+            <intent-filter>
+                <action android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.hardware.usb.action.USB_DEVICE_DETACHED" />
+            </intent-filter>
+            <meta-data
+                android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED"
+                android:resource="@xml/device_filter" />
+-->
         </activity>
     </application>
 

--- a/usbCameraTest/src/main/res/layout/activity_main.xml
+++ b/usbCameraTest/src/main/res/layout/activity_main.xml
@@ -33,8 +33,7 @@
         android:id="@+id/UVCCameraTextureView1"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_gravity="center"
-        android:background="#ff000000" />
+        android:layout_gravity="center" />
 
     <ImageButton
         android:id="@+id/camera_button"

--- a/usbCameraTest0/src/main/AndroidManifest.xml
+++ b/usbCameraTest0/src/main/AndroidManifest.xml
@@ -28,7 +28,7 @@
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
-        android:theme="@style/AppTheme" >
+        android:theme="@style/Theme.AppCompat" >
         <activity
             android:name="com.serenegiant.usbcameratest0.MainActivity"
             android:label="@string/app_name" >

--- a/usbCameraTest2/src/main/AndroidManifest.xml
+++ b/usbCameraTest2/src/main/AndroidManifest.xml
@@ -30,7 +30,7 @@
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
-        android:theme="@style/AppTheme" >
+        android:theme="@style/Theme.AppCompat" >
         <activity
             android:name="com.serenegiant.usbcameratest2.MainActivity"
             android:label="@string/app_name" >

--- a/usbCameraTest3/src/main/AndroidManifest.xml
+++ b/usbCameraTest3/src/main/AndroidManifest.xml
@@ -33,7 +33,7 @@
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
-        android:theme="@style/AppTheme" >
+        android:theme="@style/Theme.AppCompat" >
         <activity
             android:name="com.serenegiant.usbcameratest3.MainActivity"
             android:screenOrientation="sensorLandscape"

--- a/usbCameraTest4/src/main/AndroidManifest.xml
+++ b/usbCameraTest4/src/main/AndroidManifest.xml
@@ -27,6 +27,7 @@
 
     <uses-permission android:name="android.permission.RECORD_AUDIO"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
     <uses-feature android:glEsVersion="0x00020000" android:required="true" />
 
@@ -35,7 +36,7 @@
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
-        android:theme="@style/AppTheme" >
+        android:theme="@style/Theme.AppCompat" >
         <activity
             android:name=".MainActivity"
             android:label="@string/app_name"

--- a/usbCameraTest5/src/main/AndroidManifest.xml
+++ b/usbCameraTest5/src/main/AndroidManifest.xml
@@ -33,7 +33,7 @@
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
-        android:theme="@style/AppTheme" >
+        android:theme="@style/Theme.AppCompat" >
         <activity
             android:name="com.serenegiant.usbcameratest5.MainActivity"
             android:label="@string/app_name" >

--- a/usbCameraTest6/src/main/AndroidManifest.xml
+++ b/usbCameraTest6/src/main/AndroidManifest.xml
@@ -33,7 +33,7 @@
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
-        android:theme="@style/AppTheme" >
+        android:theme="@style/Theme.AppCompat" >
         <activity
             android:name="com.serenegiant.usbcameratest6.MainActivity"
             android:label="@string/app_name"

--- a/usbCameraTest7/src/main/AndroidManifest.xml
+++ b/usbCameraTest7/src/main/AndroidManifest.xml
@@ -33,7 +33,7 @@
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
-        android:theme="@style/AppTheme" >
+        android:theme="@style/Theme.AppCompat" >
         <activity
             android:name="com.serenegiant.usbcameratest7.MainActivity"
             android:label="@string/app_name"

--- a/usbCameraTest8/src/main/AndroidManifest.xml
+++ b/usbCameraTest8/src/main/AndroidManifest.xml
@@ -34,7 +34,7 @@
 		android:icon="@mipmap/ic_launcher"
 		android:label="@string/app_name"
 		android:supportsRtl="true"
-		android:theme="@style/AppTheme">
+		android:theme="@style/Theme.AppCompat">
 		<activity
 			android:name=".MainActivity"
 			android:screenOrientation="sensorLandscape"


### PR DESCRIPTION
Newer version of Android are attaching and mounting an external USB Camera as v4l devices. If one openDevice it, Android first detaches the device and immediately reattaches it under a different identifier. Hence UVCCamera fails to connect.

In order to fix this, this PR listens on ACTION_USB_DEVICE_ATTACHED, tries to detect whether the new device is the one that was intended to be opened and openDevice the new one immediately before Android remounts the v4l device.

In addition, the PR handles some Backward Compat adjustments and also fixes Notifcation handling on UsbCameraTest4 App for Android 8.1+.

Tested successful with devices on Android 5.1 and 8.1.