### PR TITLE
Make USB cameras work with Android pie

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,11 +24,11 @@ task clean(type: Delete) {
 }
 
 ext {
-	supportLibVersion = '27.1.1'  // variable that can be referenced to keep support libs consistent
+	supportLibVersion = '27.0.1'  // variable that can be referenced to keep support libs consistent
 	commonLibVersion= '2.12.4'
 	versionBuildTool = '27.0.3'
-	versionCompiler = 27
-	versionTarget = 27
+	versionCompiler = 26
+	versionTarget = 26
 	versionNameString = '1.0.0'
 	javaSourceCompatibility = JavaVersion.VERSION_1_8
 	javaTargetCompatibility = JavaVersion.VERSION_1_8

--- a/libuvccamera/build.gradle
+++ b/libuvccamera/build.gradle
@@ -36,12 +36,16 @@ android {
     defaultConfig {
         minSdkVersion 14
 		targetSdkVersion versionTarget
-    }
+	}
 
     buildTypes {
         release {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
+            minifyEnabled true
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-project.txt'
+			debuggable = true
+		}
+        debug {
+            jniDebuggable = true
         }
     }
 	sourceSets {
@@ -88,7 +92,7 @@ dependencies {
 
 	implementation "com.android.support:support-v4:${supportLibVersion}"
 	implementation "com.android.support:support-annotations:${supportLibVersion}"
-
+	implementation "com.android.support:appcompat-v7:27.0.0"
 	implementation("com.serenegiant:common:${commonLibVersion}") {
 		exclude module: 'support-v4'
 	}

--- a/libuvccamera/proguard-project.txt
+++ b/libuvccamera/proguard-project.txt
@@ -18,9 +18,6 @@
 #-keepclassmembers class fqcn.of.javascript.interface.for.webview {
 #   public *;
 #}
--keepclassmembers class com.serenegiant.usb.UVCCamera { *; }
--keep class com.serenegiant.usb.UVCCamera { *; }
--keep public interface com.serenegiant.usb.IStatusCallback
--keep public interface com.serenegiant.usb.IFrameCallback
--keep public interface com.serenegiant.usb.IButtonCallback
-
+-keepclassmembers class com.serenegiant.usb.* { *; }
+-keep class com.serenegiant.usb.* { *; }
+-keep public interface com.serenegiant.usb.*

--- a/libuvccamera/src/main/AndroidManifest.xml
+++ b/libuvccamera/src/main/AndroidManifest.xml
@@ -25,7 +25,7 @@
     package="com.serenegiant.uvccamera"
     android:versionCode="2"
     android:versionName="1.1" >
-
+    <uses-feature android:name="android.hardware.usb.host" />
     <uses-sdk
         android:minSdkVersion="14"
         android:targetSdkVersion="22" />

--- a/libuvccamera/src/main/java/com/serenegiant/usb/CameraDialog.java
+++ b/libuvccamera/src/main/java/com/serenegiant/usb/CameraDialog.java
@@ -192,7 +192,7 @@ public class CameraDialog extends DialogFragment {
 	public void updateDevices() {
 //		mUSBMonitor.dumpDevices();
 		final List<DeviceFilter> filter = DeviceFilter.getDeviceFilters(getActivity(), R.xml.device_filter);
-		mDeviceListAdapter = new DeviceListAdapter(getActivity(), mUSBMonitor.getDeviceList(filter.get(0)));
+		mDeviceListAdapter = new DeviceListAdapter(getActivity(), mUSBMonitor.getDeviceList(filter));
 		mSpinner.setAdapter(mDeviceListAdapter);
 	}
 

--- a/libuvccamera/src/main/java/com/serenegiant/usb/USBMonitor.java
+++ b/libuvccamera/src/main/java/com/serenegiant/usb/USBMonitor.java
@@ -53,7 +53,7 @@ import com.serenegiant.utils.HandlerThreadHandler;
 
 public final class USBMonitor {
 
-	private static final boolean DEBUG = false;	// TODO set false on production
+	private static final boolean DEBUG = true;	// TODO set false on production
 	private static final String TAG = "USBMonitor";
 
 	private static final String ACTION_USB_PERMISSION_BASE = "com.serenegiant.USB_PERMISSION.";
@@ -982,6 +982,8 @@ public final class USBMonitor {
 			}
 			mBusNum = busnum;
 			mDevNum = devnum;
+
+			try {
 //			if (DEBUG) {
 				if (mConnection != null) {
 					final int desc = mConnection.getFileDescriptor();
@@ -991,6 +993,9 @@ public final class USBMonitor {
 					Log.e(TAG, "could not connect to device " + name);
 				}
 //			}
+			} catch (Throwable e){
+				Log.e(TAG, "UsbControlBlock Throwable:" + e.toString());
+			}
 		}
 
 		/**

--- a/libuvccamera/src/main/jni/Application.mk
+++ b/libuvccamera/src/main/jni/Application.mk
@@ -27,6 +27,7 @@
 #NDK_TOOLCHAIN_VERSION := 4.9
 
 APP_PLATFORM := android-14
-APP_ABI := armeabi armeabi-v7a x86 mips
+APP_ABI := arm64-v8a armeabi-v7a
 #APP_OPTIM := debug
 APP_OPTIM := release
+

--- a/libuvccamera/src/main/jni/UVCCamera/UVCPreview.cpp
+++ b/libuvccamera/src/main/jni/UVCCamera/UVCPreview.cpp
@@ -333,9 +333,9 @@ int UVCPreview::startPreview() {
 		mIsRunning = true;
 		pthread_mutex_lock(&preview_mutex);
 		{
-			if (LIKELY(mPreviewWindow)) {
+//			if (LIKELY(mPreviewWindow)) {
 				result = pthread_create(&preview_thread, NULL, preview_thread_func, (void *)this);
-			}
+//	}
 		}
 		pthread_mutex_unlock(&preview_mutex);
 		if (UNLIKELY(result != EXIT_SUCCESS)) {
@@ -533,7 +533,9 @@ void UVCPreview::do_preview(uvc_stream_ctrl_t *ctrl) {
 					result = uvc_mjpeg2yuyv(frame_mjpeg, frame);   // MJPEG => yuyv
 					recycle_frame(frame_mjpeg);
 					if (LIKELY(!result)) {
-						frame = draw_preview_one(frame, &mPreviewWindow, uvc_any2rgbx, 4);
+						if (mPreviewWindow) {
+						    frame = draw_preview_one(frame, &mPreviewWindow, uvc_any2rgbx, 4);
+						}
 						addCaptureFrame(frame);
 					} else {
 						recycle_frame(frame);
@@ -545,7 +547,9 @@ void UVCPreview::do_preview(uvc_stream_ctrl_t *ctrl) {
 			for ( ; LIKELY(isRunning()) ; ) {
 				frame = waitPreviewFrame();
 				if (LIKELY(frame)) {
-					frame = draw_preview_one(frame, &mPreviewWindow, uvc_any2rgbx, 4);
+					if (mPreviewWindow) {
+						frame = draw_preview_one(frame, &mPreviewWindow, uvc_any2rgbx, 4);
+					}
 					addCaptureFrame(frame);
 				}
 			}

--- a/libuvccamera/src/main/jni/libusb/libusb/descriptor.c
+++ b/libuvccamera/src/main/jni/libusb/libusb/descriptor.c
@@ -22,6 +22,19 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
+#define LOCAL_DEBUG 0
+
+#if 0	// デバッグ情報を出さない時1
+	#ifndef LOG_NDEBUG
+		#define	LOG_NDEBUG		// LOGV/LOGD/MARKを出力しない時
+		#endif
+	#undef USE_LOGALL			// 指定したLOGxだけを出力
+#else
+	#define USE_LOGALL
+	#undef LOG_NDEBUG
+	#undef NDEBUG
+	#define GET_RAW_DESCRIPTOR
+#endif
 
 #include <errno.h>
 #include <stdint.h>
@@ -293,7 +306,6 @@ static int parse_interface(libusb_context *ctx,
 		size -= ifp->bLength;
 
 		begin = buffer;
-
 		/* Skip over any interface, class or vendor descriptors */
 		while (size >= LIBUSB_DT_HEADER_SIZE/*DESC_HEADER_LENGTH*/) {
 			usbi_parse_descriptor(buffer, "bb", &header, 0);

--- a/libuvccamera/src/main/jni/libusb/libusb/os/android_usbfs.c
+++ b/libuvccamera/src/main/jni/libusb/libusb/os/android_usbfs.c
@@ -2726,6 +2726,9 @@ static int handle_iso_completion(struct libusb_device_handle *handle,	// XXX add
 
 	usbi_mutex_lock(&itransfer->lock);
 	for (i = 0; i < num_urbs; i++) {
+	    if (tpriv->iso_urbs == NULL) {
+            break;
+        }
 		if (urb == tpriv->iso_urbs[i]) {
 			urb_idx = i + 1;
 			break;

--- a/libuvccamera/src/main/jni/utilbase.h
+++ b/libuvccamera/src/main/jni/utilbase.h
@@ -203,7 +203,7 @@
 #endif
 
 #define		ENTER()				LOGD("begin")
-#define		RETURN(code,type)	{type RESULT = code; LOGD("end (%d)", (int)RESULT); return RESULT;}
+#define		RETURN(code,type)	{type RESULT = code; LOGD("end (%d)", (long)RESULT); return RESULT;}
 #define		RET(code)			{LOGD("end"); return code;}
 #define		EXIT()				{LOGD("end"); return;}
 #define		PRE_EXIT()			LOGD("end")

--- a/libuvccamera/src/main/res/xml/device_filter.xml
+++ b/libuvccamera/src/main/res/xml/device_filter.xml
@@ -25,4 +25,5 @@
 
 <usb>
 	<usb-device class="239" subclass="2" />	<!-- all device of UVC -->
+	<usb-device class="14" subclass="2" />
 </usb>

--- a/usbCameraCommon/build.gradle
+++ b/usbCameraCommon/build.gradle
@@ -33,21 +33,25 @@ android {
    	}
 
     defaultConfig {
-        minSdkVersion 18
+        minSdkVersion 14
         targetSdkVersion versionTarget
 
     }
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            debuggable = true
+        }
+        debug {
+            jniDebuggable = true
         }
     }
 }
 
 dependencies {
 	api fileTree(dir: 'libs', include: ['*.jar'])
-
+	implementation "com.android.support:appcompat-v7:${supportLibVersion}"
 	implementation "com.android.support:support-v4:${supportLibVersion}"
 	implementation "com.android.support:support-annotations:${supportLibVersion}"
 

--- a/usbCameraTest/build.gradle
+++ b/usbCameraTest/build.gradle
@@ -38,19 +38,22 @@ android {
 		targetSdkVersion versionTarget
 		versionCode 8
 		versionName "3.00"
-    }
+	}
 
     buildTypes {
         release {
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-project.txt'
-        }
+			debuggable = true
+			signingConfig signingConfigs.debug
+		}
     }
 }
 
 dependencies {
 	api fileTree(dir: 'libs', include: ['*.jar'])
 
+	implementation "com.android.support:appcompat-v7:${supportLibVersion}"
 	implementation "com.android.support:support-v4:${supportLibVersion}"
 	implementation "com.android.support:support-annotations:${supportLibVersion}"
 

--- a/usbCameraTest/src/main/AndroidManifest.xml
+++ b/usbCameraTest/src/main/AndroidManifest.xml
@@ -23,7 +23,7 @@
   -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.serenegiant.usbcameratest" >
-
+    <uses-feature android:name="android.hardware.usb.host" />
     <application
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
@@ -35,7 +35,10 @@
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
+                <action android:name="android.hardware.usb.action.USB_ACCESSORY_ATTACHED" />
             </intent-filter>
+            <meta-data android:name="android.hardware.usb.action.USB_ACCESSORY_ATTACHED"
+                android:resource="@xml/device_filter" />
         </activity>
     </application>
 

--- a/usbCameraTest/src/main/AndroidManifest.xml
+++ b/usbCameraTest/src/main/AndroidManifest.xml
@@ -35,11 +35,8 @@
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
-                <action android:name="android.hardware.usb.action.USB_ACCESSORY_ATTACHED" />
             </intent-filter>
-            <meta-data android:name="android.hardware.usb.action.USB_ACCESSORY_ATTACHED"
-                android:resource="@xml/device_filter" />
-        </activity>
+         </activity>
     </application>
 
 </manifest>

--- a/usbCameraTest/src/main/res/layout/activity_main.xml
+++ b/usbCameraTest/src/main/res/layout/activity_main.xml
@@ -33,8 +33,7 @@
         android:id="@+id/UVCCameraTextureView1"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_gravity="center"
-        android:background="#ff000000" />
+        android:layout_gravity="center" />
 
     <ImageButton
         android:id="@+id/camera_button"

--- a/usbCameraTest/src/main/res/values-v11/styles.xml
+++ b/usbCameraTest/src/main/res/values-v11/styles.xml
@@ -27,7 +27,7 @@
         Base application theme for API 11+. This theme completely replaces
         AppBaseTheme from res/values/styles.xml on API 11+ devices.
     -->
-    <style name="AppBaseTheme" parent="android:Theme.Holo.Light">
+    <style name="AppBaseTheme" parent="Theme.AppCompat.Light">
         <!-- API 11 theme customizations can go here. -->
     </style>
 

--- a/usbCameraTest/src/main/res/values-v14/styles.xml
+++ b/usbCameraTest/src/main/res/values-v14/styles.xml
@@ -28,7 +28,7 @@
         AppBaseTheme from BOTH res/values/styles.xml and
         res/values-v11/styles.xml on API 14+ devices.
     -->
-    <style name="AppBaseTheme" parent="android:Theme.Holo.Light.DarkActionBar">
+    <style name="AppBaseTheme" parent="Theme.AppCompat.Light.DarkActionBar">
         <!-- API 14 theme customizations can go here. -->
     </style>
 

--- a/usbCameraTest/src/main/res/values/styles.xml
+++ b/usbCameraTest/src/main/res/values/styles.xml
@@ -28,7 +28,7 @@
         Base application theme, dependent on API level. This theme is replaced
         by AppBaseTheme from res/values-vXX/styles.xml on newer devices.
     -->
-    <style name="AppBaseTheme" parent="android:Theme.Light">
+    <style name="AppBaseTheme" parent="Theme.AppCompat">
         <!--
             Theme customizations available in newer API levels can go in
             res/values-vXX/styles.xml, while customizations related to

--- a/usbCameraTest/src/main/res/xml/device_filter.xml
+++ b/usbCameraTest/src/main/res/xml/device_filter.xml
@@ -25,5 +25,6 @@
 
 <usb>
 	<usb-device class="239" subclass="2" />	<!-- all device of UVC -->
+	<usb-device class="14" subclass="2" />
 	<usb-device vendor-id="0x1b80" />
 </usb>

--- a/usbCameraTest0/src/main/res/values-v11/styles.xml
+++ b/usbCameraTest0/src/main/res/values-v11/styles.xml
@@ -27,7 +27,7 @@
         Base application theme for API 11+. This theme completely replaces
         AppBaseTheme from res/values/styles.xml on API 11+ devices.
     -->
-    <style name="AppBaseTheme" parent="android:Theme.Holo.Light">
+    <style name="AppBaseTheme" parent="Theme.AppCompat.Light">
         <!-- API 11 theme customizations can go here. -->
     </style>
 

--- a/usbCameraTest0/src/main/res/values-v14/styles.xml
+++ b/usbCameraTest0/src/main/res/values-v14/styles.xml
@@ -28,7 +28,7 @@
         AppBaseTheme from BOTH res/values/styles.xml and
         res/values-v11/styles.xml on API 14+ devices.
     -->
-    <style name="AppBaseTheme" parent="android:Theme.Holo.Light.DarkActionBar">
+    <style name="AppBaseTheme" parent="Theme.AppCompat.Light.DarkActionBar">
         <!-- API 14 theme customizations can go here. -->
     </style>
 

--- a/usbCameraTest2/build.gradle
+++ b/usbCameraTest2/build.gradle
@@ -52,6 +52,7 @@ dependencies {
 	api fileTree(dir: 'libs', include: ['*.jar'])
 
 	implementation "com.android.support:support-v4:${supportLibVersion}"
+	implementation "com.android.support:appcompat-v7:${supportLibVersion}"
 	implementation "com.android.support:support-annotations:${supportLibVersion}"
 
 	implementation("com.serenegiant:common:${commonLibVersion}") {

--- a/usbCameraTest2/src/main/res/layout/activity_main.xml
+++ b/usbCameraTest2/src/main/res/layout/activity_main.xml
@@ -35,8 +35,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_centerInParent="true"
-        android:layout_gravity="center"
-        android:background="#ff000000" />
+        android:layout_gravity="center" />
 
     <ImageView
         android:id="@+id/imageView1"

--- a/usbCameraTest2/src/main/res/values-v11/styles.xml
+++ b/usbCameraTest2/src/main/res/values-v11/styles.xml
@@ -27,7 +27,7 @@
         Base application theme for API 11+. This theme completely replaces
         AppBaseTheme from res/values/styles.xml on API 11+ devices.
     -->
-    <style name="AppBaseTheme" parent="android:Theme.Holo.Light">
+    <style name="AppBaseTheme" parent="Theme.AppCompat.Light">
         <!-- API 11 theme customizations can go here. -->
     </style>
 

--- a/usbCameraTest2/src/main/res/values-v14/styles.xml
+++ b/usbCameraTest2/src/main/res/values-v14/styles.xml
@@ -28,7 +28,7 @@
         AppBaseTheme from BOTH res/values/styles.xml and
         res/values-v11/styles.xml on API 14+ devices.
     -->
-    <style name="AppBaseTheme" parent="android:Theme.Holo.Light.DarkActionBar">
+    <style name="AppBaseTheme" parent="Theme.AppCompat.Light.DarkActionBar">
         <!-- API 14 theme customizations can go here. -->
     </style>
 

--- a/usbCameraTest2/src/main/res/xml/device_filter.xml
+++ b/usbCameraTest2/src/main/res/xml/device_filter.xml
@@ -25,4 +25,5 @@
 
 <usb>
 	<usb-device class="239" subclass="2" />	<!-- all device of UVC -->
+	<usb-device class="14" subclass="2" />
 </usb>

--- a/usbCameraTest3/build.gradle
+++ b/usbCameraTest3/build.gradle
@@ -52,6 +52,7 @@ dependencies {
 	api fileTree(dir: 'libs', include: ['*.jar'])
 
 	implementation "com.android.support:support-v4:${supportLibVersion}"
+	implementation "com.android.support:appcompat-v7:${supportLibVersion}"
 	implementation "com.android.support:support-annotations:${supportLibVersion}"
 
 	implementation("com.serenegiant:common:${commonLibVersion}") {

--- a/usbCameraTest3/src/main/res/values-v11/styles.xml
+++ b/usbCameraTest3/src/main/res/values-v11/styles.xml
@@ -27,7 +27,7 @@
         Base application theme for API 11+. This theme completely replaces
         AppBaseTheme from res/values/styles.xml on API 11+ devices.
     -->
-    <style name="AppBaseTheme" parent="android:Theme.Holo.Light">
+    <style name="AppBaseTheme" parent="Theme.AppCompat.Light">
         <!-- API 11 theme customizations can go here. -->
     </style>
 

--- a/usbCameraTest3/src/main/res/values-v14/styles.xml
+++ b/usbCameraTest3/src/main/res/values-v14/styles.xml
@@ -28,7 +28,7 @@
         AppBaseTheme from BOTH res/values/styles.xml and
         res/values-v11/styles.xml on API 14+ devices.
     -->
-    <style name="AppBaseTheme" parent="android:Theme.Holo.Light.DarkActionBar">
+    <style name="AppBaseTheme" parent="Theme.AppCompat.Light.DarkActionBar">
         <!-- API 14 theme customizations can go here. -->
     </style>
 

--- a/usbCameraTest3/src/main/res/xml/device_filter.xml
+++ b/usbCameraTest3/src/main/res/xml/device_filter.xml
@@ -25,4 +25,5 @@
 
 <usb>
 	<usb-device class="239" subclass="2" />	<!-- all device of UVC -->
+	<usb-device class="14" subclass="2" />
 </usb>

--- a/usbCameraTest4/build.gradle
+++ b/usbCameraTest4/build.gradle
@@ -52,6 +52,7 @@ dependencies {
 	api fileTree(dir: 'libs', include: ['*.jar'])
 
 	implementation "com.android.support:support-v4:${supportLibVersion}"
+	implementation "com.android.support:appcompat-v7:${supportLibVersion}"
 	implementation "com.android.support:support-annotations:${supportLibVersion}"
 
 	implementation("com.serenegiant:common:${commonLibVersion}") {

--- a/usbCameraTest4/src/main/AndroidManifest.xml
+++ b/usbCameraTest4/src/main/AndroidManifest.xml
@@ -42,18 +42,8 @@
             android:launchMode="singleTask" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
-			<intent-filter>
-				<action android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED" />
-			</intent-filter>
-			<intent-filter>
-				<action android:name="android.hardware.usb.action.USB_DEVICE_DETACHED" />
-			</intent-filter>
-			<meta-data
-				android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED"
-				android:resource="@xml/device_filter" />
             </activity>
         <service
             android:name="com.serenegiant.service.UVCService"

--- a/usbCameraTest4/src/main/res/values-v11/styles.xml
+++ b/usbCameraTest4/src/main/res/values-v11/styles.xml
@@ -27,7 +27,7 @@
         Base application theme for API 11+. This theme completely replaces
         AppBaseTheme from res/values/styles.xml on API 11+ devices.
     -->
-    <style name="AppBaseTheme" parent="android:Theme.Holo.Light">
+    <style name="AppBaseTheme" parent="Theme.AppCompat.Light">
         <!-- API 11 theme customizations can go here. -->
     </style>
 

--- a/usbCameraTest4/src/main/res/values-v14/styles.xml
+++ b/usbCameraTest4/src/main/res/values-v14/styles.xml
@@ -28,7 +28,7 @@
         AppBaseTheme from BOTH res/values/styles.xml and
         res/values-v11/styles.xml on API 14+ devices.
     -->
-    <style name="AppBaseTheme" parent="android:Theme.Holo.Light.DarkActionBar">
+    <style name="AppBaseTheme" parent="Theme.AppCompat.Light.DarkActionBar">
         <!-- API 14 theme customizations can go here. -->
     </style>
 

--- a/usbCameraTest4/src/main/res/xml/device_filter.xml
+++ b/usbCameraTest4/src/main/res/xml/device_filter.xml
@@ -25,4 +25,5 @@
 
 <usb>
 	<usb-device class="239" subclass="2" />	<!-- all device of UVC -->
+	<usb-device class="14" subclass="2" />
 </usb>

--- a/usbCameraTest5/src/main/res/values-v11/styles.xml
+++ b/usbCameraTest5/src/main/res/values-v11/styles.xml
@@ -27,7 +27,7 @@
         Base application theme for API 11+. This theme completely replaces
         AppBaseTheme from res/values/styles.xml on API 11+ devices.
     -->
-    <style name="AppBaseTheme" parent="android:Theme.Holo.Light">
+    <style name="AppBaseTheme" parent="Theme.AppCompat.Light">
         <!-- API 11 theme customizations can go here. -->
     </style>
 

--- a/usbCameraTest5/src/main/res/values-v14/styles.xml
+++ b/usbCameraTest5/src/main/res/values-v14/styles.xml
@@ -28,7 +28,7 @@
         AppBaseTheme from BOTH res/values/styles.xml and
         res/values-v11/styles.xml on API 14+ devices.
     -->
-    <style name="AppBaseTheme" parent="android:Theme.Holo.Light.DarkActionBar">
+    <style name="AppBaseTheme" parent="Theme.AppCompat.Light.DarkActionBar">
         <!-- API 14 theme customizations can go here. -->
     </style>
 

--- a/usbCameraTest5/src/main/res/xml/device_filter.xml
+++ b/usbCameraTest5/src/main/res/xml/device_filter.xml
@@ -25,4 +25,7 @@
 
 <usb>
 	<usb-device class="239" subclass="2" />	<!-- all device of UVC -->
+	<usb-device class="14" subclass="2" />
+	<usb-device class="0" subclass="9" />
+	<usb-device class="2" subclass="0" />
 </usb>

--- a/usbCameraTest6/src/main/res/values-v11/styles.xml
+++ b/usbCameraTest6/src/main/res/values-v11/styles.xml
@@ -27,7 +27,7 @@
         Base application theme for API 11+. This theme completely replaces
         AppBaseTheme from res/values/styles.xml on API 11+ devices.
     -->
-    <style name="AppBaseTheme" parent="android:Theme.Holo.Light">
+    <style name="AppBaseTheme" parent="Theme.AppCompat.Light">
         <!-- API 11 theme customizations can go here. -->
     </style>
 

--- a/usbCameraTest6/src/main/res/values-v14/styles.xml
+++ b/usbCameraTest6/src/main/res/values-v14/styles.xml
@@ -28,7 +28,7 @@
         AppBaseTheme from BOTH res/values/styles.xml and
         res/values-v11/styles.xml on API 14+ devices.
     -->
-    <style name="AppBaseTheme" parent="android:Theme.Holo.Light.DarkActionBar">
+    <style name="AppBaseTheme" parent="Theme.AppCompat.Light.DarkActionBar">
         <!-- API 14 theme customizations can go here. -->
     </style>
 

--- a/usbCameraTest6/src/main/res/xml/device_filter.xml
+++ b/usbCameraTest6/src/main/res/xml/device_filter.xml
@@ -25,4 +25,5 @@
 
 <usb>
 	<usb-device class="239" subclass="2" />	<!-- all device of UVC -->
+	<usb-device class="14" subclass="2" />
 </usb>

--- a/usbCameraTest7/src/main/res/values-v11/styles.xml
+++ b/usbCameraTest7/src/main/res/values-v11/styles.xml
@@ -27,7 +27,7 @@
         Base application theme for API 11+. This theme completely replaces
         AppBaseTheme from res/values/styles.xml on API 11+ devices.
     -->
-    <style name="AppBaseTheme" parent="android:Theme.Holo.Light">
+    <style name="AppBaseTheme" parent="Theme.AppCompat.Light">
         <!-- API 11 theme customizations can go here. -->
     </style>
 

--- a/usbCameraTest7/src/main/res/values-v14/styles.xml
+++ b/usbCameraTest7/src/main/res/values-v14/styles.xml
@@ -28,7 +28,7 @@
         AppBaseTheme from BOTH res/values/styles.xml and
         res/values-v11/styles.xml on API 14+ devices.
     -->
-    <style name="AppBaseTheme" parent="android:Theme.Holo.Light.DarkActionBar">
+    <style name="AppBaseTheme" parent="Theme.AppCompat.Light.DarkActionBar">
         <!-- API 14 theme customizations can go here. -->
     </style>
 

--- a/usbCameraTest7/src/main/res/xml/device_filter.xml
+++ b/usbCameraTest7/src/main/res/xml/device_filter.xml
@@ -25,4 +25,5 @@
 
 <usb>
 	<usb-device class="239" subclass="2" />	<!-- all device of UVC -->
+	<usb-device class="14" subclass="2" />
 </usb>

--- a/usbCameraTest8/src/main/res/values/styles.xml
+++ b/usbCameraTest8/src/main/res/values/styles.xml
@@ -24,7 +24,7 @@
 <resources>
 
 	<!-- Base application theme. -->
-	<style name="AppTheme" parent="android:Theme.Holo.Light.DarkActionBar">
+	<style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
 		<!-- Customize your theme here. -->
 	</style>
 

--- a/usbCameraTest8/src/main/res/xml/device_filter.xml
+++ b/usbCameraTest8/src/main/res/xml/device_filter.xml
@@ -24,5 +24,8 @@
   -->
 
 <usb>
+	<usb-device class="14" subclass="2" />
 	<usb-device class="239" subclass="2" />	<!-- all device of UVC -->
+	<usb-device class="0" subclass="9" />
+	<usb-device class="2" subclass="0" />
 </usb>


### PR DESCRIPTION
1. BaseActivity inherits from AppCompatActivity. Changed all the styles to use AppCompat themes. Included appcompat-v7 in build files.
2. Made the build work with proguard by keeping all the USB classes
3. Modified device_filter.xml files to include <<usb-device class="14" subclass="2" />, this makes our camera work for Android pie

This work includes PR #454. That was not enough to make our camera work under Android pie. These other changes were needed. Apparently under Android pie not all UVC camera are of class 239. Some are class 14.

Nola Donato
Samsung Research VR / AR team