### PR TITLE
Fix crash when Android target SDK > 27

### DIFF
--- a/libuvccamera/src/main/jni/libusb/libusb/os/android_usbfs.c
+++ b/libuvccamera/src/main/jni/libusb/libusb/os/android_usbfs.c
@@ -2932,7 +2932,7 @@ static int reap_for_handle(struct libusb_device_handle *handle) {
 	
 	//if not check status, will crash when target > 27
 	//current error status is -108
-	if(urb->status < 0){
+	if(urb->status == -108){
 	    return LIBUSB_ERROR_OTHER;
 	}
 	

--- a/libuvccamera/src/main/jni/libusb/libusb/os/android_usbfs.c
+++ b/libuvccamera/src/main/jni/libusb/libusb/os/android_usbfs.c
@@ -2726,6 +2726,9 @@ static int handle_iso_completion(struct libusb_device_handle *handle,	// XXX add
 
 	usbi_mutex_lock(&itransfer->lock);
 	for (i = 0; i < num_urbs; i++) {
+		 if(tpriv->iso_urbs == NULL){
+	        	return LIBUSB_TRANSFER_ERROR;
+	    	}
 		if (urb == tpriv->iso_urbs[i]) {
 			urb_idx = i + 1;
 			break;
@@ -2926,7 +2929,13 @@ static int reap_for_handle(struct libusb_device_handle *handle) {
 
 	usbi_dbg("urb type=%d status=%d transferred=%d",
 		urb->type, urb->status, urb->actual_length);
-
+	
+	//if not check status, will crash when target > 27
+	//current error status is -108
+	if(urb->status < 0){
+	    return LIBUSB_ERROR_OTHER;
+	}
+	
 	switch (transfer->type) {
 	case LIBUSB_TRANSFER_TYPE_ISOCHRONOUS:
 		return handle_iso_completion(handle, itransfer, urb);


### PR DESCRIPTION
this crash will appear when Android target SDK > 27:
signal 6 (SIGABRT), code -6 (SI_TKILL), fault addr --------
Abort message: 'FORTIFY: pthread_mutex_lock called on a destroyed mutex (0x7a4eb694b4)'